### PR TITLE
Fix DoH and query logging memory leaks

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -15,6 +15,10 @@ type DNSClient interface {
 	Resolve(ctx context.Context, req *dns.Msg) (*dns.Msg, error)
 }
 
+type lifecycleDNSClient interface {
+	Close() error
+}
+
 func NewDNSClient(cfg config.UpstreamServer, bootstrapper *resolver.Bootstrapper) (DNSClient, error) {
 	switch cfg.Protocol {
 	case "udp":
@@ -30,6 +34,16 @@ func NewDNSClient(cfg config.UpstreamServer, bootstrapper *resolver.Bootstrapper
 	default:
 		return nil, fmt.Errorf("不支持的上游协议: %s", cfg.Protocol)
 	}
+}
+
+func CloseDNSClient(c DNSClient) error {
+	if c == nil {
+		return nil
+	}
+	if closer, ok := c.(lifecycleDNSClient); ok {
+		return closer.Close()
+	}
+	return nil
 }
 
 func ensureECS(req *dns.Msg, ecsIP string) {

--- a/internal/client/doh.go
+++ b/internal/client/doh.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"doh-autoproxy/internal/config"
@@ -21,9 +22,16 @@ import (
 )
 
 type DoHClient struct {
-	cfg          config.UpstreamServer
-	bootstrapper *resolver.Bootstrapper
-	httpClient   *http.Client
+	cfg            config.UpstreamServer
+	bootstrapper   *resolver.Bootstrapper
+	httpClient     *http.Client
+	httpTransport  *http.Transport
+	http3Transport *http3.Transport
+	quicTransport  *quic.Transport
+	udpConn        *net.UDPConn
+	h3InitOnce     sync.Once
+	h3InitErr      error
+	closeOnce      sync.Once
 }
 
 func NewDoHClient(cfg config.UpstreamServer, b *resolver.Bootstrapper) *DoHClient {
@@ -41,66 +49,92 @@ func (c *DoHClient) initHTTPClient() {
 	}
 
 	if c.cfg.EnableH3 {
-		c.httpClient = &http.Client{
-			Transport: &http3.Transport{
-				TLSClientConfig: tlsConfig,
-				QUICConfig: &quic.Config{
-					MaxIdleTimeout: 30 * time.Second,
-				},
-				Dial: func(ctx context.Context, addr string, tlsCfg *tls.Config, cfg *quic.Config) (*quic.Conn, error) {
-					host, port, err := net.SplitHostPort(addr)
-					if err != nil {
-						return nil, err
-					}
-					ip, err := c.bootstrapper.LookupIP(ctx, host)
-					if err != nil {
-						return nil, fmt.Errorf("H3 bootstrap解析失败: %w", err)
-					}
-					resolvedAddr := net.JoinHostPort(ip, port)
-					udpAddr, err := net.ResolveUDPAddr("udp", resolvedAddr)
-					if err != nil {
-						return nil, err
-					}
-					udpConn, err := net.ListenUDP("udp", nil)
-					if err != nil {
-						return nil, err
-					}
-					tr := &quic.Transport{Conn: udpConn}
-					return tr.Dial(ctx, udpAddr, tlsCfg, cfg)
-				},
+		h3Transport := &http3.Transport{
+			TLSClientConfig: tlsConfig,
+			QUICConfig: &quic.Config{
+				MaxIdleTimeout: 30 * time.Second,
 			},
-			Timeout: 10 * time.Second,
+		}
+		h3Transport.Dial = func(ctx context.Context, addr string, tlsCfg *tls.Config, cfg *quic.Config) (*quic.Conn, error) {
+			transport, err := c.getOrCreateQUICTransport()
+			if err != nil {
+				return nil, err
+			}
+
+			host, port, err := net.SplitHostPort(addr)
+			if err != nil {
+				return nil, err
+			}
+			ip, err := c.bootstrapper.LookupIP(ctx, host)
+			if err != nil {
+				return nil, fmt.Errorf("H3 bootstrap解析失败: %w", err)
+			}
+			udpAddr, err := net.ResolveUDPAddr("udp", net.JoinHostPort(ip, port))
+			if err != nil {
+				return nil, err
+			}
+
+			return transport.Dial(ctx, udpAddr, tlsCfg, cfg)
+		}
+
+		c.http3Transport = h3Transport
+		c.httpClient = &http.Client{
+			Transport: h3Transport,
+			Timeout:   10 * time.Second,
 		}
 		return
 	}
 
-	c.httpClient = &http.Client{
-		Transport: &http.Transport{
-			Proxy: http.ProxyFromEnvironment,
-			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-				host, port, err := net.SplitHostPort(addr)
-				if err != nil {
-					return nil, err
-				}
-				ip, err := c.bootstrapper.LookupIP(ctx, host)
-				if err != nil {
-					return nil, err
-				}
-				d := net.Dialer{
-					Timeout:   30 * time.Second,
-					KeepAlive: 30 * time.Second,
-				}
-				return d.DialContext(ctx, network, net.JoinHostPort(ip, port))
-			},
-			ForceAttemptHTTP2:     true,
-			TLSClientConfig:       tlsConfig,
-			MaxIdleConns:          100,
-			IdleConnTimeout:       90 * time.Second,
-			TLSHandshakeTimeout:   10 * time.Second,
-			ExpectContinueTimeout: 1 * time.Second,
+	c.httpTransport = &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			host, port, err := net.SplitHostPort(addr)
+			if err != nil {
+				return nil, err
+			}
+			ip, err := c.bootstrapper.LookupIP(ctx, host)
+			if err != nil {
+				return nil, err
+			}
+			d := net.Dialer{
+				Timeout:   30 * time.Second,
+				KeepAlive: 30 * time.Second,
+			}
+			return d.DialContext(ctx, network, net.JoinHostPort(ip, port))
 		},
-		Timeout: 10 * time.Second,
+		ForceAttemptHTTP2:     true,
+		TLSClientConfig:       tlsConfig,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
 	}
+
+	c.httpClient = &http.Client{
+		Transport: c.httpTransport,
+		Timeout:   10 * time.Second,
+	}
+}
+
+func (c *DoHClient) getOrCreateQUICTransport() (*quic.Transport, error) {
+	c.h3InitOnce.Do(func() {
+		udpConn, err := net.ListenUDP("udp", nil)
+		if err != nil {
+			c.h3InitErr = err
+			return
+		}
+		c.udpConn = udpConn
+		c.quicTransport = &quic.Transport{Conn: udpConn}
+	})
+
+	if c.h3InitErr != nil {
+		return nil, c.h3InitErr
+	}
+	if c.quicTransport == nil {
+		return nil, fmt.Errorf("HTTP/3 transport unavailable")
+	}
+
+	return c.quicTransport, nil
 }
 
 func (c *DoHClient) Resolve(ctx context.Context, req *dns.Msg) (*dns.Msg, error) {
@@ -158,4 +192,31 @@ func (c *DoHClient) Resolve(ctx context.Context, req *dns.Msg) (*dns.Msg, error)
 	}
 
 	return responseMsg, nil
+}
+
+func (c *DoHClient) Close() error {
+	var firstErr error
+
+	c.closeOnce.Do(func() {
+		if c.httpTransport != nil {
+			c.httpTransport.CloseIdleConnections()
+		}
+		if c.http3Transport != nil {
+			if err := c.http3Transport.Close(); err != nil && firstErr == nil {
+				firstErr = err
+			}
+		}
+		if c.quicTransport != nil {
+			if err := c.quicTransport.Close(); err != nil && firstErr == nil {
+				firstErr = err
+			}
+		}
+		if c.udpConn != nil {
+			if err := c.udpConn.Close(); err != nil && firstErr == nil {
+				firstErr = err
+			}
+		}
+	})
+
+	return firstErr
 }

--- a/internal/client/dot.go
+++ b/internal/client/dot.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"doh-autoproxy/internal/config"
@@ -19,6 +20,7 @@ type DoTClient struct {
 	bootstrapper *resolver.Bootstrapper
 	pool         chan *dns.Conn
 	poolInit     sync.Once
+	closed       atomic.Bool
 }
 
 func NewDoTClient(cfg config.UpstreamServer, b *resolver.Bootstrapper) *DoTClient {
@@ -76,6 +78,13 @@ func (c *DoTClient) resolvePipeline(ctx context.Context, req *dns.Msg) (*dns.Msg
 	}
 
 	defer func() {
+		if conn == nil {
+			return
+		}
+		if c.closed.Load() {
+			conn.Close()
+			return
+		}
 		c.pool <- conn
 	}()
 
@@ -165,4 +174,26 @@ func (c *DoTClient) dialConn(ctx context.Context) (*dns.Conn, error) {
 		return nil, err
 	}
 	return conn, nil
+}
+
+func (c *DoTClient) Close() error {
+	c.closed.Store(true)
+	if c.pool == nil {
+		return nil
+	}
+
+	var firstErr error
+	for {
+		select {
+		case conn := <-c.pool:
+			if conn == nil {
+				continue
+			}
+			if err := conn.Close(); err != nil && firstErr == nil {
+				firstErr = err
+			}
+		default:
+			return firstErr
+		}
+	}
 }

--- a/internal/client/stats.go
+++ b/internal/client/stats.go
@@ -72,3 +72,7 @@ func (s *StatsClient) GetStats() map[string]interface{} {
 		"avg_duration_ms": avg,
 	}
 }
+
+func (s *StatsClient) Close() error {
+	return CloseDNSClient(s.Client)
+}

--- a/internal/client/tcp.go
+++ b/internal/client/tcp.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"doh-autoproxy/internal/config"
@@ -18,6 +19,7 @@ type TCPClient struct {
 	bootstrapper *resolver.Bootstrapper
 	pool         chan *dns.Conn
 	poolInit     sync.Once
+	closed       atomic.Bool
 }
 
 func NewTCPClient(cfg config.UpstreamServer, b *resolver.Bootstrapper) *TCPClient {
@@ -74,6 +76,13 @@ func (c *TCPClient) resolvePipeline(ctx context.Context, req *dns.Msg) (*dns.Msg
 	}
 
 	defer func() {
+		if conn == nil {
+			return
+		}
+		if c.closed.Load() {
+			conn.Close()
+			return
+		}
 		c.pool <- conn
 	}()
 
@@ -148,4 +157,26 @@ func (c *TCPClient) resolveAddr(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("bootstrap failed: %w", err)
 	}
 	return net.JoinHostPort(ip, port), nil
+}
+
+func (c *TCPClient) Close() error {
+	c.closed.Store(true)
+	if c.pool == nil {
+		return nil
+	}
+
+	var firstErr error
+	for {
+		select {
+		case conn := <-c.pool:
+			if conn == nil {
+				continue
+			}
+			if err := conn.Close(); err != nil && firstErr == nil {
+				firstErr = err
+			}
+		default:
+			return firstErr
+		}
+	}
 }

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -39,7 +39,6 @@ type ServiceManager struct {
 func NewServiceManager(initialCfg *config.Config) *ServiceManager {
 	return &ServiceManager{
 		Config:         initialCfg,
-		QueryLog:       querylog.NewQueryLogger(initialCfg.QueryLog.Enabled, initialCfg.QueryLog.MaxHistory, initialCfg.QueryLog.MaxSizeMB, initialCfg.QueryLog.File, initialCfg.QueryLog.SaveToFile),
 		stopAutoUpdate: make(chan struct{}),
 	}
 }
@@ -83,6 +82,10 @@ func (m *ServiceManager) Reload(newCfg *config.Config) error {
 		log.Println("GeoData 配置未更改，保留现有的 Geo 数据库以加快重新加载。")
 	}
 
+	if err := m.stopInternal(); err != nil {
+		log.Printf("Warning: Error stopping services during reload: %v", err)
+	}
+
 	if m.Config.QueryLog.SaveToFile && !newCfg.QueryLog.SaveToFile {
 		logFile := m.Config.QueryLog.File
 		if logFile == "" {
@@ -92,10 +95,6 @@ func (m *ServiceManager) Reload(newCfg *config.Config) error {
 		if err := os.Remove(logFile); err != nil && !os.IsNotExist(err) {
 			log.Printf("删除日志文件失败: %v", err)
 		}
-	}
-
-	if err := m.stopInternal(); err != nil {
-		log.Printf("Warning: Error stopping services during reload: %v", err)
 	}
 
 	m.Config = newCfg
@@ -244,6 +243,11 @@ func (m *ServiceManager) startInternal() error {
 	if cfg.QueryLog.SaveToFile && logFile == "" {
 		logFile = "query.log"
 	}
+	if m.QueryLog != nil {
+		if err := m.QueryLog.Close(); err != nil {
+			log.Printf("关闭旧查询日志器失败: %v", err)
+		}
+	}
 	m.QueryLog = querylog.NewQueryLogger(cfg.QueryLog.Enabled, cfg.QueryLog.MaxHistory, cfg.QueryLog.MaxSizeMB, logFile, cfg.QueryLog.SaveToFile)
 
 	m.Router = router.NewRouter(cfg, m.GeoManager, m.QueryLog)
@@ -307,33 +311,58 @@ func (m *ServiceManager) startInternal() error {
 func (m *ServiceManager) stopInternal() error {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
+	var firstErr error
 
 	if m.ACMEServer != nil {
-		m.ACMEServer.Shutdown(ctx)
+		if err := m.ACMEServer.Shutdown(ctx); err != nil && firstErr == nil {
+			firstErr = err
+		}
 		m.ACMEServer = nil
 	}
 
 	if m.DNSServer != nil {
-		m.DNSServer.Stop()
+		if err := m.DNSServer.Stop(); err != nil && firstErr == nil {
+			firstErr = err
+		}
 		m.DNSServer = nil
 	}
 
 	if m.DoTServer != nil {
-		m.DoTServer.Stop()
+		if err := m.DoTServer.Stop(); err != nil && firstErr == nil {
+			firstErr = err
+		}
 		m.DoTServer = nil
 	}
 
 	if m.DoQServer != nil {
-		m.DoQServer.Stop()
+		if err := m.DoQServer.Stop(); err != nil && firstErr == nil {
+			firstErr = err
+		}
 		m.DoQServer = nil
 	}
 
 	if m.DoHServer != nil {
-		m.DoHServer.Stop()
+		if err := m.DoHServer.Stop(); err != nil && firstErr == nil {
+			firstErr = err
+		}
 		m.DoHServer = nil
 	}
 
-	return nil
+	if m.Router != nil {
+		if err := m.Router.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+		m.Router = nil
+	}
+
+	if m.QueryLog != nil {
+		if err := m.QueryLog.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+		m.QueryLog = nil
+	}
+
+	return firstErr
 }
 
 func (m *ServiceManager) GetCertManager() *util.CertManager {

--- a/internal/querylog/querylog.go
+++ b/internal/querylog/querylog.go
@@ -59,10 +59,16 @@ type QueryLogger struct {
 	stats      Stats
 
 	persistedLogCount int64
+	fileQueue         chan LogEntry
+	stopWriter        chan struct{}
+	writerDone        chan struct{}
+	closeOnce         sync.Once
+	closed            atomic.Bool
 }
 
 const defaultMaxMemoryLogs = 5000
 const qpsWindow = 10 * time.Second
+const maxFileWriteQueueSize = 1024
 
 func NewQueryLogger(enabled bool, maxHistory, maxSizeMB int, filePath string, saveToFile bool) *QueryLogger {
 	if maxSizeMB <= 0 {
@@ -93,9 +99,44 @@ func NewQueryLogger(enabled bool, maxHistory, maxSizeMB int, filePath string, sa
 
 	if enabled && saveToFile && filePath != "" {
 		l.restoreStatsFromFile()
+		l.startFileWriter()
 	}
 
 	return l
+}
+
+func (l *QueryLogger) startFileWriter() {
+	queueSize := l.maxHistory
+	if queueSize > maxFileWriteQueueSize {
+		queueSize = maxFileWriteQueueSize
+	}
+	if queueSize < 64 {
+		queueSize = 64
+	}
+
+	l.fileQueue = make(chan LogEntry, queueSize)
+	l.stopWriter = make(chan struct{})
+	l.writerDone = make(chan struct{})
+
+	go func() {
+		defer close(l.writerDone)
+
+		for {
+			select {
+			case entry := <-l.fileQueue:
+				l.appendToFile(entry)
+			case <-l.stopWriter:
+				for {
+					select {
+					case entry := <-l.fileQueue:
+						l.appendToFile(entry)
+					default:
+						return
+					}
+				}
+			}
+		}
+	}()
 }
 
 func (l *QueryLogger) restoreStatsFromFile() {
@@ -123,12 +164,15 @@ func (l *QueryLogger) restoreStatsFromFile() {
 }
 
 func (l *QueryLogger) AddLog(entry *LogEntry) {
-	if !l.enabled {
+	if !l.enabled || l.closed.Load() {
 		return
 	}
 
 	l.mu.Lock()
-	defer l.mu.Unlock()
+	if l.closed.Load() {
+		l.mu.Unlock()
+		return
+	}
 
 	entry.ID = l.nextID
 	l.nextID++
@@ -140,9 +184,50 @@ func (l *QueryLogger) AddLog(entry *LogEntry) {
 	l.updateTotals(entry)
 	l.addToMemory(entry)
 
-	if l.saveToFile && l.filePath != "" {
-		go l.appendToFile(*entry)
+	shouldPersist := l.saveToFile && l.filePath != "" && l.fileQueue != nil
+	var entryCopy LogEntry
+	if shouldPersist {
+		entryCopy = cloneEntry(*entry)
 	}
+	l.mu.Unlock()
+
+	if shouldPersist {
+		l.enqueueFileWrite(entryCopy)
+	}
+}
+
+func cloneEntry(entry LogEntry) LogEntry {
+	if len(entry.AnswerRecords) > 0 {
+		entry.AnswerRecords = append([]AnswerRecord(nil), entry.AnswerRecords...)
+	}
+	return entry
+}
+
+func (l *QueryLogger) enqueueFileWrite(entry LogEntry) {
+	if l.fileQueue == nil || l.closed.Load() {
+		return
+	}
+
+	select {
+	case l.fileQueue <- entry:
+	default:
+		// 队列满时直接回退到同步写，避免额外 goroutine 堆积。
+		l.appendToFile(entry)
+	}
+}
+
+func (l *QueryLogger) Close() error {
+	l.closeOnce.Do(func() {
+		l.closed.Store(true)
+		if l.stopWriter != nil {
+			close(l.stopWriter)
+		}
+		if l.writerDone != nil {
+			<-l.writerDone
+		}
+	})
+
+	return nil
 }
 
 func (l *QueryLogger) updateTotals(entry *LogEntry) {
@@ -155,15 +240,23 @@ func (l *QueryLogger) updateTotals(entry *LogEntry) {
 }
 
 func (l *QueryLogger) addToMemory(entry *LogEntry) {
-	l.logs = append(l.logs, entry)
 	l.stats.TopClients[entry.ClientIP]++
 	l.stats.TopDomains[entry.Domain]++
 
-	if len(l.logs) > l.maxHistory {
-		evicted := l.logs[0]
-		l.logs = l.logs[1:]
-		l.decrementTopCounters(evicted)
+	if len(l.logs) < l.maxHistory {
+		l.logs = append(l.logs, entry)
+		return
 	}
+
+	if len(l.logs) == 0 {
+		l.logs = append(l.logs, entry)
+		return
+	}
+
+	evicted := l.logs[0]
+	copy(l.logs, l.logs[1:])
+	l.logs[len(l.logs)-1] = entry
+	l.decrementTopCounters(evicted)
 }
 
 func (l *QueryLogger) decrementTopCounters(entry *LogEntry) {
@@ -193,7 +286,10 @@ func (l *QueryLogger) recordRecentLog(ts time.Time) {
 		firstValid++
 	}
 	if firstValid > 0 {
-		l.recentLogs = l.recentLogs[firstValid:]
+		remaining := len(l.recentLogs) - firstValid
+		copy(l.recentLogs, l.recentLogs[firstValid:])
+		clear(l.recentLogs[remaining:])
+		l.recentLogs = l.recentLogs[:remaining]
 	}
 }
 

--- a/internal/querylog/querylog_test.go
+++ b/internal/querylog/querylog_test.go
@@ -2,6 +2,10 @@ package querylog
 
 import (
 	"math"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 	"time"
 )
@@ -71,5 +75,58 @@ func TestTopStatsTrackBoundedHistory(t *testing.T) {
 	}
 	if len(logs) != 2 || logs[0].Domain != "third.example" || logs[1].Domain != "second.example" {
 		t.Fatalf("unexpected bounded log order: %#v", logs)
+	}
+}
+
+func TestSaveToFileUsesBoundedWriters(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "query.log")
+	before := runtime.NumGoroutine()
+
+	logger := NewQueryLogger(true, 32, 10, path, true)
+	t.Cleanup(func() {
+		if err := logger.Close(); err != nil {
+			t.Fatalf("close logger: %v", err)
+		}
+	})
+
+	for i := 0; i < 2000; i++ {
+		logger.AddLog(&LogEntry{
+			ClientIP: "127.0.0.1",
+			Domain:   "example.com",
+			Upstream: "Rule(CN)",
+			Status:   "NOERROR",
+		})
+	}
+
+	after := runtime.NumGoroutine()
+	if delta := after - before; delta > 20 {
+		t.Fatalf("expected bounded writer goroutines, got delta=%d (before=%d after=%d)", delta, before, after)
+	}
+}
+
+func TestCloseFlushesQueuedLogs(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "query.log")
+	logger := NewQueryLogger(true, 32, 10, path, true)
+
+	for i := 0; i < 50; i++ {
+		logger.AddLog(&LogEntry{
+			ClientIP: "127.0.0.1",
+			Domain:   "flush.example",
+			Upstream: "Rule(CN)",
+			Status:   "NOERROR",
+		})
+	}
+
+	if err := logger.Close(); err != nil {
+		t.Fatalf("close logger: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read log file: %v", err)
+	}
+
+	if lines := strings.Count(string(data), "\n"); lines != 50 {
+		t.Fatalf("expected 50 persisted lines, got %d", lines)
 	}
 }

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -95,6 +95,26 @@ func (r *Router) GetUpstreamStats() []interface{} {
 	return stats
 }
 
+func (r *Router) Close() error {
+	if r == nil {
+		return nil
+	}
+
+	var firstErr error
+	for _, s := range r.cnStats {
+		if err := s.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	for _, s := range r.overseasStats {
+		if err := s.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+
+	return firstErr
+}
+
 func (r *Router) Route(ctx context.Context, req *dns.Msg, clientIP string) (*dns.Msg, error) {
 	start := time.Now()
 	if len(req.Question) == 0 {


### PR DESCRIPTION
## Summary
- reuse a single HTTP/3 QUIC transport per DoH client and close upstream transports during reload/shutdown
- replace per-log goroutines with a bounded query log writer queue and flush it on shutdown
- add regression tests for bounded log writers and queued log flushing

## Testing
- go test ./...